### PR TITLE
fix upgrade_1022

### DIFF
--- a/CRM/Apiprocessing/Config.php
+++ b/CRM/Apiprocessing/Config.php
@@ -476,13 +476,32 @@ class CRM_Apiprocessing_Config {
   /**
    * Getter for new participant custom group id
    * @return mixed
+   * @throws \CiviCRM_API3_Exception
    */
-  public function getNewParticipantCustomGroupId() {
-    if (isset($this->_newParticipantCustomGroup['id'])) {
-      return $this->_newParticipantCustomGroup['id'];
+  public static function getNewParticipantCustomGroupId() {
+    if (self::$_singleton === NULL) {
+      try {
+        $newParticipantCustomGroup =
+          civicrm_api3(
+            'CustomGroup',
+            'getsingle',
+            ['name' => 'fzfd_participant_data_new']
+          );
+        return $newParticipantCustomGroup['id'];
+      } catch (\CiviCRM_API3_Exception $ex) {
+        throw new \CiviCRM_API3_Exception('Could not find custom data '
+          . 'set ParticipantNew in ' . __METHOD__ . ' contact your system '
+          . 'administrator. Error from API CustomGroup getsingle: '
+          . $ex->getMessage()
+        );
+      }
     }
     else {
-      return $this->_newParticipantCustomGroup;
+      $instance = CRM_Apiprocessing_Config::$_singleton;
+      if (isset($instance->_newParticipantCustomGroup['id'])) {
+        return $instance->_newParticipantCustomGroup['id'];
+      }
+      return $instance->_newParticipantCustomGroup;
     }
   }
 

--- a/CRM/Apiprocessing/Upgrader.php
+++ b/CRM/Apiprocessing/Upgrader.php
@@ -188,10 +188,11 @@ class CRM_Apiprocessing_Upgrader extends CRM_Apiprocessing_Upgrader_Base {
    * Upgrade 1022 - add additional fields participant new
    *
    * @return bool
+   * @throws \CiviCRM_API3_Exception
    */
   public function upgrade_1022() {
     $this->ctx->log->info('Applying update 1022 - add additional fields participant new');
-    $customGroupId = CRM_Apiprocessing_Config::singleton()->getNewParticipantCustomGroupId();
+    $customGroupId = CRM_Apiprocessing_Config::getNewParticipantCustomGroupId();
     if ($customGroupId) {
       $customFields = $this->getAdditionalParticipantFields();
       foreach ($customFields as $customFieldName => $customFieldData) {


### PR DESCRIPTION
This change avoids instantiating the CRM_Apiprocessing_Config object at a time when the new custom fields do not yet exist, which otherwise causes an exception during the upgrade.