### PR TITLE
upgrade civix code

### DIFF
--- a/apiprocessing.civix.php
+++ b/apiprocessing.civix.php
@@ -7,9 +7,9 @@
  * extension.
  */
 class CRM_Apiprocessing_ExtensionUtil {
-  const SHORT_NAME = "apiprocessing";
-  const LONG_NAME = "de.forumzfd.apiprocessing";
-  const CLASS_PREFIX = "CRM_Apiprocessing";
+  const SHORT_NAME = 'apiprocessing';
+  const LONG_NAME = 'de.forumzfd.apiprocessing';
+  const CLASS_PREFIX = 'CRM_Apiprocessing';
 
   /**
    * Translate a string using the extension's domain.
@@ -24,9 +24,9 @@ class CRM_Apiprocessing_ExtensionUtil {
    *   Translated text.
    * @see ts
    */
-  public static function ts($text, $params = array()) {
+  public static function ts($text, $params = []) {
     if (!array_key_exists('domain', $params)) {
-      $params['domain'] = array(self::LONG_NAME, NULL);
+      $params['domain'] = [self::LONG_NAME, NULL];
     }
     return ts($text, $params);
   }
@@ -82,7 +82,7 @@ use CRM_Apiprocessing_ExtensionUtil as E;
 /**
  * (Delegated) Implements hook_civicrm_config().
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_config
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_config
  */
 function _apiprocessing_civix_civicrm_config(&$config = NULL) {
   static $configured = FALSE;
@@ -100,7 +100,7 @@ function _apiprocessing_civix_civicrm_config(&$config = NULL) {
     array_unshift($template->template_dir, $extDir);
   }
   else {
-    $template->template_dir = array($extDir, $template->template_dir);
+    $template->template_dir = [$extDir, $template->template_dir];
   }
 
   $include_path = $extRoot . PATH_SEPARATOR . get_include_path();
@@ -112,7 +112,7 @@ function _apiprocessing_civix_civicrm_config(&$config = NULL) {
  *
  * @param $files array(string)
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_xmlMenu
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_xmlMenu
  */
 function _apiprocessing_civix_civicrm_xmlMenu(&$files) {
   foreach (_apiprocessing_civix_glob(__DIR__ . '/xml/Menu/*.xml') as $file) {
@@ -123,7 +123,7 @@ function _apiprocessing_civix_civicrm_xmlMenu(&$files) {
 /**
  * Implements hook_civicrm_install().
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_install
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_install
  */
 function _apiprocessing_civix_civicrm_install() {
   _apiprocessing_civix_civicrm_config();
@@ -135,12 +135,12 @@ function _apiprocessing_civix_civicrm_install() {
 /**
  * Implements hook_civicrm_postInstall().
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_postInstall
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_postInstall
  */
 function _apiprocessing_civix_civicrm_postInstall() {
   _apiprocessing_civix_civicrm_config();
   if ($upgrader = _apiprocessing_civix_upgrader()) {
-    if (is_callable(array($upgrader, 'onPostInstall'))) {
+    if (is_callable([$upgrader, 'onPostInstall'])) {
       $upgrader->onPostInstall();
     }
   }
@@ -149,7 +149,7 @@ function _apiprocessing_civix_civicrm_postInstall() {
 /**
  * Implements hook_civicrm_uninstall().
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_uninstall
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_uninstall
  */
 function _apiprocessing_civix_civicrm_uninstall() {
   _apiprocessing_civix_civicrm_config();
@@ -161,12 +161,12 @@ function _apiprocessing_civix_civicrm_uninstall() {
 /**
  * (Delegated) Implements hook_civicrm_enable().
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_enable
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_enable
  */
 function _apiprocessing_civix_civicrm_enable() {
   _apiprocessing_civix_civicrm_config();
   if ($upgrader = _apiprocessing_civix_upgrader()) {
-    if (is_callable(array($upgrader, 'onEnable'))) {
+    if (is_callable([$upgrader, 'onEnable'])) {
       $upgrader->onEnable();
     }
   }
@@ -175,13 +175,13 @@ function _apiprocessing_civix_civicrm_enable() {
 /**
  * (Delegated) Implements hook_civicrm_disable().
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_disable
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_disable
  * @return mixed
  */
 function _apiprocessing_civix_civicrm_disable() {
   _apiprocessing_civix_civicrm_config();
   if ($upgrader = _apiprocessing_civix_upgrader()) {
-    if (is_callable(array($upgrader, 'onDisable'))) {
+    if (is_callable([$upgrader, 'onDisable'])) {
       $upgrader->onDisable();
     }
   }
@@ -193,10 +193,11 @@ function _apiprocessing_civix_civicrm_disable() {
  * @param $op string, the type of operation being performed; 'check' or 'enqueue'
  * @param $queue CRM_Queue_Queue, (for 'enqueue') the modifiable list of pending up upgrade tasks
  *
- * @return mixed  based on op. for 'check', returns array(boolean) (TRUE if upgrades are pending)
- *                for 'enqueue', returns void
+ * @return mixed
+ *   based on op. for 'check', returns array(boolean) (TRUE if upgrades are pending)
+ *   for 'enqueue', returns void
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_upgrade
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_upgrade
  */
 function _apiprocessing_civix_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL) {
   if ($upgrader = _apiprocessing_civix_upgrader()) {
@@ -217,62 +218,41 @@ function _apiprocessing_civix_upgrader() {
 }
 
 /**
- * Search directory tree for files which match a glob pattern
+ * Search directory tree for files which match a glob pattern.
  *
  * Note: Dot-directories (like "..", ".git", or ".svn") will be ignored.
- * Note: In Civi 4.3+, delegate to CRM_Utils_File::findFiles()
+ * Note: Delegate to CRM_Utils_File::findFiles(), this function kept only
+ * for backward compatibility of extension code that uses it.
  *
- * @param $dir string, base dir
- * @param $pattern string, glob pattern, eg "*.txt"
- * @return array(string)
+ * @param string $dir base dir
+ * @param string $pattern , glob pattern, eg "*.txt"
+ *
+ * @return array
  */
 function _apiprocessing_civix_find_files($dir, $pattern) {
-  if (is_callable(array('CRM_Utils_File', 'findFiles'))) {
-    return CRM_Utils_File::findFiles($dir, $pattern);
-  }
-
-  $todos = array($dir);
-  $result = array();
-  while (!empty($todos)) {
-    $subdir = array_shift($todos);
-    foreach (_apiprocessing_civix_glob("$subdir/$pattern") as $match) {
-      if (!is_dir($match)) {
-        $result[] = $match;
-      }
-    }
-    if ($dh = opendir($subdir)) {
-      while (FALSE !== ($entry = readdir($dh))) {
-        $path = $subdir . DIRECTORY_SEPARATOR . $entry;
-        if ($entry{0} == '.') {
-        }
-        elseif (is_dir($path)) {
-          $todos[] = $path;
-        }
-      }
-      closedir($dh);
-    }
-  }
-  return $result;
+  return CRM_Utils_File::findFiles($dir, $pattern);
 }
+
 /**
  * (Delegated) Implements hook_civicrm_managed().
  *
  * Find any *.mgd.php files, merge their content, and return.
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_managed
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_managed
  */
 function _apiprocessing_civix_civicrm_managed(&$entities) {
   $mgdFiles = _apiprocessing_civix_find_files(__DIR__, '*.mgd.php');
+  sort($mgdFiles);
   foreach ($mgdFiles as $file) {
     $es = include $file;
     foreach ($es as $e) {
       if (empty($e['module'])) {
         $e['module'] = E::LONG_NAME;
       }
-      $entities[] = $e;
       if (empty($e['params']['version'])) {
         $e['params']['version'] = '3';
       }
+      $entities[] = $e;
     }
   }
 }
@@ -284,7 +264,7 @@ function _apiprocessing_civix_civicrm_managed(&$entities) {
  *
  * Note: This hook only runs in CiviCRM 4.4+.
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_caseTypes
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_caseTypes
  */
 function _apiprocessing_civix_civicrm_caseTypes(&$caseTypes) {
   if (!is_dir(__DIR__ . '/xml/case')) {
@@ -295,14 +275,13 @@ function _apiprocessing_civix_civicrm_caseTypes(&$caseTypes) {
     $name = preg_replace('/\.xml$/', '', basename($file));
     if ($name != CRM_Case_XMLProcessor::mungeCaseType($name)) {
       $errorMessage = sprintf("Case-type file name is malformed (%s vs %s)", $name, CRM_Case_XMLProcessor::mungeCaseType($name));
-      CRM_Core_Error::fatal($errorMessage);
-      // throw new CRM_Core_Exception($errorMessage);
+      throw new CRM_Core_Exception($errorMessage);
     }
-    $caseTypes[$name] = array(
+    $caseTypes[$name] = [
       'module' => E::LONG_NAME,
       'name' => $name,
       'file' => $file,
-    );
+    ];
   }
 }
 
@@ -313,7 +292,7 @@ function _apiprocessing_civix_civicrm_caseTypes(&$caseTypes) {
  *
  * Note: This hook only runs in CiviCRM 4.5+.
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_angularModules
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_angularModules
  */
 function _apiprocessing_civix_civicrm_angularModules(&$angularModules) {
   if (!is_dir(__DIR__ . '/ang')) {
@@ -332,6 +311,25 @@ function _apiprocessing_civix_civicrm_angularModules(&$angularModules) {
 }
 
 /**
+ * (Delegated) Implements hook_civicrm_themes().
+ *
+ * Find any and return any files matching "*.theme.php"
+ */
+function _apiprocessing_civix_civicrm_themes(&$themes) {
+  $files = _apiprocessing_civix_glob(__DIR__ . '/*.theme.php');
+  foreach ($files as $file) {
+    $themeMeta = include $file;
+    if (empty($themeMeta['name'])) {
+      $themeMeta['name'] = preg_replace(':\.theme\.php$:', '', basename($file));
+    }
+    if (empty($themeMeta['ext'])) {
+      $themeMeta['ext'] = E::LONG_NAME;
+    }
+    $themes[$themeMeta['name']] = $themeMeta;
+  }
+}
+
+/**
  * Glob wrapper which is guaranteed to return an array.
  *
  * The documentation for glob() says, "On some systems it is impossible to
@@ -341,11 +339,12 @@ function _apiprocessing_civix_civicrm_angularModules(&$angularModules) {
  *
  * @link http://php.net/glob
  * @param string $pattern
- * @return array, possibly empty
+ *
+ * @return array
  */
 function _apiprocessing_civix_glob($pattern) {
   $result = glob($pattern);
-  return is_array($result) ? $result : array();
+  return is_array($result) ? $result : [];
 }
 
 /**
@@ -356,16 +355,18 @@ function _apiprocessing_civix_glob($pattern) {
  *    'Mailing', or 'Administer/System Settings'
  * @param array $item - the item to insert (parent/child attributes will be
  *    filled for you)
+ *
+ * @return bool
  */
 function _apiprocessing_civix_insert_navigation_menu(&$menu, $path, $item) {
   // If we are done going down the path, insert menu
   if (empty($path)) {
-    $menu[] = array(
-      'attributes' => array_merge(array(
+    $menu[] = [
+      'attributes' => array_merge([
         'label'      => CRM_Utils_Array::value('name', $item),
         'active'     => 1,
-      ), $item),
-    );
+      ], $item),
+    ];
     return TRUE;
   }
   else {
@@ -376,9 +377,9 @@ function _apiprocessing_civix_insert_navigation_menu(&$menu, $path, $item) {
     foreach ($menu as $key => &$entry) {
       if ($entry['attributes']['name'] == $first) {
         if (!isset($entry['child'])) {
-          $entry['child'] = array();
+          $entry['child'] = [];
         }
-        $found = _apiprocessing_civix_insert_navigation_menu($entry['child'], implode('/', $path), $item, $key);
+        $found = _apiprocessing_civix_insert_navigation_menu($entry['child'], implode('/', $path), $item);
       }
     }
     return $found;
@@ -389,7 +390,7 @@ function _apiprocessing_civix_insert_navigation_menu(&$menu, $path, $item) {
  * (Delegated) Implements hook_civicrm_navigationMenu().
  */
 function _apiprocessing_civix_navigationMenu(&$nodes) {
-  if (!is_callable(array('CRM_Core_BAO_Navigation', 'fixNavigationMenu'))) {
+  if (!is_callable(['CRM_Core_BAO_Navigation', 'fixNavigationMenu'])) {
     _apiprocessing_civix_fixNavigationMenu($nodes);
   }
 }
@@ -431,17 +432,11 @@ function _apiprocessing_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $paren
 /**
  * (Delegated) Implements hook_civicrm_alterSettingsFolders().
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_alterSettingsFolders
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_alterSettingsFolders
  */
 function _apiprocessing_civix_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
-  static $configured = FALSE;
-  if ($configured) {
-    return;
-  }
-  $configured = TRUE;
-
   $settingsDir = __DIR__ . DIRECTORY_SEPARATOR . 'settings';
-  if (is_dir($settingsDir) && !in_array($settingsDir, $metaDataFolders)) {
+  if (!in_array($settingsDir, $metaDataFolders) && is_dir($settingsDir)) {
     $metaDataFolders[] = $settingsDir;
   }
 }
@@ -451,28 +446,24 @@ function _apiprocessing_civix_civicrm_alterSettingsFolders(&$metaDataFolders = N
  *
  * Find any *.entityType.php files, merge their content, and return.
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_entityTypes
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_entityTypes
  */
-
 function _apiprocessing_civix_civicrm_entityTypes(&$entityTypes) {
-  $entityTypes = array_merge($entityTypes, array (
-    'CRM_Apiprocessing_DAO_FzfdContribution' => 
-    array (
+  $entityTypes = array_merge($entityTypes, [
+    'CRM_Apiprocessing_DAO_FzfdContribution' => [
       'name' => 'FzfdContribution',
       'class' => 'CRM_Apiprocessing_DAO_FzfdContribution',
       'table' => 'civicrm_fzfd_contribution',
-    ),
-    'CRM_Apiprocessing_DAO_FzfdMandate' => 
-    array (
+    ],
+    'CRM_Apiprocessing_DAO_FzfdMandate' => [
       'name' => 'FzfdMandate',
       'class' => 'CRM_Apiprocessing_DAO_FzfdMandate',
       'table' => 'civicrm_fzfd_mandate',
-    ),
-    'CRM_Apiprocessing_DAO_FzfdTemp' => 
-    array (
+    ],
+    'CRM_Apiprocessing_DAO_FzfdTemp' => [
       'name' => 'FzfdTemp',
       'class' => 'CRM_Apiprocessing_DAO_FzfdTemp',
       'table' => 'civicrm_fzfd_temp',
-    ),
-  ));
+    ],
+  ]);
 }


### PR DESCRIPTION
I just re-executed the `civix generate:module de.forumzfd.apiprocessing` command to regenerate the civix code and get rid of the deprecation warnings.

My testing shows no problems with this change.