### PR TITLE
Find existing organizations

### DIFF
--- a/CRM/Apiprocessing/Contact.php
+++ b/CRM/Apiprocessing/Contact.php
@@ -57,9 +57,20 @@ class CRM_Apiprocessing_Contact {
    */
   public function findOrganizationId($params) {
     if (!empty($params)) {
-      $params['contact_type'] = "Organization";
+      $orgaParams['contact_type'] = "Organization";
+      $orgaParams["organization_name"] = $params["organization_name"];
+      $orgaParams["xcm_profile"] = CRM_Apiprocessing_Settings::singleton()
+        ->get('fzfd_xcm_organization_profile');
+      foreach ($params as $key => $value) {
+        $keySegments = explode("_", $key);
+        if ($keySegments[0] == "organization" && $keySegments[1] != "name") {
+          array_shift($keySegments);
+          $key = implode("_", $keySegments);
+          $orgaParams[$key] = $value;
+        }
+      }
       try {
-        $organization = civicrm_api3('Contact', 'getorcreate', $params);
+        $organization = civicrm_api3('Contact', 'getorcreate', $orgaParams);
         if (isset($organization['id'])) {
           return (int) $organization['id'];
         }

--- a/CRM/Apiprocessing/Form/Settings.php
+++ b/CRM/Apiprocessing/Form/Settings.php
@@ -15,6 +15,7 @@ class CRM_Apiprocessing_Form_Settings extends CRM_Core_Form {
   private $_cycleDaysList = array();
   private $_locationTypeList = array();
   private $_participantStatusList = [];
+  private $_xcmProfiles = [];
 
   /**
    * Method to set the participant status list
@@ -146,6 +147,19 @@ class CRM_Apiprocessing_Form_Settings extends CRM_Core_Form {
   }
 
   /**
+   * Retrieves XCM profiles (if supported). 'default' profile is always
+   * available
+   */
+  private function setXcmOrganizationProfileList() {
+    if (method_exists('CRM_Xcm_Configuration', 'getProfileList')) {
+      $xcmProfiles = CRM_Xcm_Configuration::getProfileList();
+    }
+    asort($xcmProfiles);
+    $this->_xcmProfiles = $xcmProfiles;
+  }
+
+
+  /**
    * Overridden parent method to initiate form
    *
    * @access public
@@ -159,6 +173,7 @@ class CRM_Apiprocessing_Form_Settings extends CRM_Core_Form {
     $this->setCycleDaysList();
     $this->setLocationTypeList();
     $this->setParticipantStatusList();
+    $this->setXcmOrganizationProfileList();
   }
 
   /**
@@ -189,6 +204,7 @@ class CRM_Apiprocessing_Form_Settings extends CRM_Core_Form {
     $this->add('select', 'fzfd_valid_uploads', E::ts('Valid files for upload bewerbungsschreiben and lebenslauf'), CRM_Apiprocessing_Attachment::getValidUploads(), TRUE,
       ['id' => 'fzfd_valid_uploads', 'multiple' => 'multiple', 'class' => 'crm-select2']);
     $this->add('select', 'fzfd_billing_location_type', ts('Location Type for Rechnungsadresse'), $this->_locationTypeList, TRUE);
+    $this->add('select', 'fzfd_xcm_organization_profile', ts('XCM profile to match organizations'), $this->_xcmProfiles, TRUE);
 
     // add buttons
     $this->addButtons(array(
@@ -237,6 +253,7 @@ class CRM_Apiprocessing_Form_Settings extends CRM_Core_Form {
         'fzfd_participant_status_id' => $formValues['fzfd_participant_status_id'],
         'fzfd_valid_uploads' => $formValues['fzfd_valid_uploads'],
         'fzfd_billing_location_type' => $formValues['fzfd_billing_location_type'],
+        'fzfd_xcm_organization_profile' => $formValues['fzfd_xcm_organization_profile']
       );
       if (!empty($formValues['default_cycle_day_sepa'])) {
         $data['default_cycle_day_sepa'] = $formValues['default_cycle_day_sepa'];

--- a/resources/settings.json
+++ b/resources/settings.json
@@ -29,5 +29,6 @@
         "text\/plain"
     ],
     "fzfd_billing_location_type": "5",
-    "default_cycle_day_sepa": "1"
+    "default_cycle_day_sepa": "1",
+    "fzfd_xcm_organization_profile": "default"
 }

--- a/templates/CRM/Apiprocessing/Form/Settings.tpl
+++ b/templates/CRM/Apiprocessing/Form/Settings.tpl
@@ -37,6 +37,11 @@
     <div class="clear"></div>
   </div>
   <div class="crm-section">
+    <div class="label">{$form.fzfd_xcm_organization_profile.label}</div>
+    <div class="content crm-select-container">{$form.fzfd_xcm_organization_profile.html}</div>
+    <div class="clear"></div>
+  </div>
+  <div class="crm-section">
     <div class="label">{$form.fzfdperson_groups.label}</div>
     <div class="content crm-select-container">{$form.fzfdperson_groups.html}</div>
     <div class="clear"></div>


### PR DESCRIPTION
At the moment, the `CRM_Apiprocessing_Contact.findOrganizationId` method does not really search for existing organizations, because it passes all contact information to the `Contact.getorcreate` API. This results in a new organization being created every time.

I have made a few changes:
- I filter out the contact information passed to `Contact.getorcreate` that has no relation to the organization
- The `Contact.getorcreate` function now also uses an XCM profile to match organizations
- The XCM profile used is configurable in the extension settings